### PR TITLE
fix: address missing port_directions in cell definition

### DIFF
--- a/include/rinox/io/json/json_parser.hpp
+++ b/include/rinox/io/json/json_parser.hpp
@@ -243,7 +243,7 @@ private:
           auto it = cell.port_dirs.find( pin );
           if ( it != cell.port_dirs.end() )
             return it->second == "output";
-          return ( pin == "Y" || pin == "O" || pin == "Q" || pin == "ZN" );
+          return reader_.is_output_pin( cell.type, pin );
         };
 
         for ( auto const& kv : cell.connections )


### PR DESCRIPTION
The json parser before this PR required json files specifying the port directions ("input"/"output") for each pin. This PR makes the parser more flexible by supporting parsing cells whose pin direction is not specified.