### PR TITLE
Update RINOX IO

### DIFF
--- a/include/rinox/io/json/json_parser.hpp
+++ b/include/rinox/io/json/json_parser.hpp
@@ -97,18 +97,18 @@ public:
                const reader_t& rdr,
                lorina::diagnostic_engine* de = nullptr,
                std::string_view module = "top" )
-      : jstream_( in, module ), reader_( rdr ), diag_( de ), on_action_( PackedFns(
-                                                                 ModuleInstFn( [&]( const std::string mn,
-                                                                                    const std::vector<std::string>& params,
-                                                                                    const std::string inst,
-                                                                                    const std::vector<std::pair<std::string, std::string>>& pin2pin ) {
-                                                                   reader_.on_module_instantiation( mn, params, inst, pin2pin );
-                                                                 } ),
-                                                                 CellFn( [&]( const std::vector<std::pair<std::string, std::string>>& in_map,
-                                                                              const std::vector<std::pair<std::string, std::string>>& out_map,
-                                                                              const std::vector<unsigned int>& ids ) {
-                                                                   reader_.on_cell( in_map, out_map, ids );
-                                                                 } ) ) )
+      : jstream_( in, de ), reader_( rdr ), diag_( de ), on_action_( PackedFns(
+                                                             ModuleInstFn( [&]( const std::string mn,
+                                                                                const std::vector<std::string>& params,
+                                                                                const std::string inst,
+                                                                                const std::vector<std::pair<std::string, std::string>>& pin2pin ) {
+                                                               reader_.on_module_instantiation( mn, params, inst, pin2pin );
+                                                             } ),
+                                                             CellFn( [&]( const std::vector<std::pair<std::string, std::string>>& in_map,
+                                                                          const std::vector<std::pair<std::string, std::string>>& out_map,
+                                                                          const std::vector<unsigned int>& ids ) {
+                                                               reader_.on_cell( in_map, out_map, ids );
+                                                             } ) ) )
   {
     on_action_.declare_known( "0" );
     on_action_.declare_known( "1" );

--- a/include/rinox/io/json/json_stream.hpp
+++ b/include/rinox/io/json/json_stream.hpp
@@ -107,8 +107,8 @@ enum class instance_return_code
 class json_stream
 {
 public:
-  explicit json_stream( std::istream& in, std::string_view module_to_read = "top", lorina::diagnostic_engine* diag = nullptr )
-      : module_name_( module_to_read ), diag_( diag )
+  explicit json_stream( std::istream& in, lorina::diagnostic_engine* diag = nullptr )
+      : diag_( diag )
   {
     rapidjson::IStreamWrapper isw( in );
     doc_.ParseStream( isw );
@@ -123,10 +123,10 @@ public:
       return;
     }
 
-    if ( !module_name_.empty() )
-    {
-      set_module( module_name_ );
-    }
+    std::vector<std::string> mnames = module_names();
+    assert( ( mnames.size() == 1 ) && "only stable for one module" );
+    module_name_ = mnames[0];
+    set_module( module_name_ );
   }
 
   std::vector<std::string> module_names() const

--- a/include/rinox/io/utils/reader.hpp
+++ b/include/rinox/io/utils/reader.hpp
@@ -136,7 +136,7 @@ public:
         const auto length = parse_size( size );
         for ( auto i = 0u; i < length; ++i )
         {
-          const auto sname = fmt::format( "{}[{}]", name, i );
+          const auto sname = length > 1 ? fmt::format( "{}[{}]", name, i ) : fmt::format( "{}", name );
           word.push_back( ntk_.create_pi() );
           signals_[sname] = word.back();
           if constexpr ( mockturtle::has_set_name_v<Ntk> )
@@ -351,6 +351,11 @@ public:
   bool is_output_pin( std::string const& gate_name, std::string const& pin_name ) const
   {
     return ntk_.is_output_pin( gate_name, pin_name );
+  }
+
+  unsigned int get_pin_id( std::string const& gate_name, std::string const& pin_name ) const
+  {
+    return ntk_.get_pin_id( gate_name, pin_name );
   }
 
 private:

--- a/include/rinox/io/verilog/verilog_parser.hpp
+++ b/include/rinox/io/verilog/verilog_parser.hpp
@@ -459,6 +459,9 @@ public:
       }
     } while ( token != "assign" && token != "endmodule" );
 
+    reader.sanitize_input_names();
+    reader.sanitize_output_names();
+
     while ( token != "endmodule" )
     {
       if ( token == "assign" )
@@ -1038,8 +1041,7 @@ public:
         return false;
       }
     }
-//HERE IS THE ISSUE
-
+    // HERE IS THE ISSUE
 
     on_action.call_deferred<CELL_FN>( /* dependencies */ inputs, outputs,
                                       /* gate-function params */ std::make_tuple( input_assigns, output_assigns, ids ) );

--- a/include/rinox/io/verilog/verilog_parser.hpp
+++ b/include/rinox/io/verilog/verilog_parser.hpp
@@ -965,7 +965,7 @@ public:
 
     std::vector<std::pair<std::string, std::string>> input_assigns;
     std::vector<std::pair<std::string, std::string>> output_assigns;
-    auto const ids = reader.get_binding_ids( gate_name );
+    std::vector<unsigned int> ids;
 
     while ( token != ";" && token != "endmodule" )
     {
@@ -993,6 +993,7 @@ public:
         {
           state = pin_state::OUTPUT_PIN;
           output_assigns.emplace_back( pin_name, "" );
+          ids.emplace_back( reader.get_pin_id( gate_name, pin_name ) );
         }
         else
         {
@@ -1037,6 +1038,8 @@ public:
         return false;
       }
     }
+//HERE IS THE ISSUE
+
 
     on_action.call_deferred<CELL_FN>( /* dependencies */ inputs, outputs,
                                       /* gate-function params */ std::make_tuple( input_assigns, output_assigns, ids ) );

--- a/include/rinox/libraries/augmented_library.hpp
+++ b/include/rinox/libraries/augmented_library.hpp
@@ -221,8 +221,8 @@ public:
         return id;
     }
     std::cerr << "[e] pin name " << pin_name << " not found in " << gate_name << std::endl;
+    return std::numeric_limits<unsigned int>::max();
   }
-
 
   std::optional<unsigned int> get_id( kitty::dynamic_truth_table const& tt ) const
   {

--- a/include/rinox/libraries/augmented_library.hpp
+++ b/include/rinox/libraries/augmented_library.hpp
@@ -212,6 +212,18 @@ public:
     return it->second;
   }
 
+  unsigned int get_pin_id( std::string const& gate_name, std::string const& pin_name ) const
+  {
+    auto const ids = get_binding_ids( gate_name );
+    for ( auto id : ids )
+    {
+      if ( raw_gates_[id].output_name == pin_name )
+        return id;
+    }
+    std::cerr << "[e] pin name " << pin_name << " not found in " << gate_name << std::endl;
+  }
+
+
   std::optional<unsigned int> get_id( kitty::dynamic_truth_table const& tt ) const
   {
     auto it = tt_to_index_.find( tt );

--- a/include/rinox/network/network.hpp
+++ b/include/rinox/network/network.hpp
@@ -1078,7 +1078,7 @@ public:
     return _storage->get_output_name( po_index );
   }
 
-  bool get_input_name( uint32_t const& pi_index ) const
+  std::string get_input_name( uint32_t const& pi_index ) const
   {
     return _storage->get_input_name( pi_index );
   }

--- a/include/rinox/network/network.hpp
+++ b/include/rinox/network/network.hpp
@@ -1134,6 +1134,11 @@ public:
     return _storage->get_binding_ids( f.index )[f.output];
   }
 
+  unsigned int get_pin_id( std::string const& gate_name, std::string const& pin_name ) const
+  {
+    return _storage->get_pin_id( gate_name, pin_name );
+  }
+
   auto const& get_binding( signal_t const& f ) const
   {
     return _storage->get_binding( f );

--- a/include/rinox/network/storage_network.hpp
+++ b/include/rinox/network/storage_network.hpp
@@ -1018,7 +1018,7 @@ public:
 
   std::string get_input_name( uint32_t pi_index )
   {
-    auto const f = make_signal( pi_at( pi_index ) );
+    signal_t const f{ pi_at( pi_index ), 0 };
     return get_name( f );
   }
 
@@ -1030,7 +1030,7 @@ public:
 
   void set_input_name( uint32_t pi_index, std::string const& name )
   {
-    auto const f = make_signal( pi_at( pi_index ) );
+    signal_t const f{ pi_at( pi_index ), 0 };
     names_map[f.data] = name;
   }
 

--- a/include/rinox/network/storage_network.hpp
+++ b/include/rinox/network/storage_network.hpp
@@ -1018,6 +1018,11 @@ public:
     return trav_id;
   }
 
+  unsigned int get_pin_id( std::string const& gate_name, std::string const& pin_name ) const
+  {
+    return library.get_pin_id( gate_name, pin_name );
+  }
+
   void incr_trav_id()
   {
     if ( trav_id > ( std::numeric_limits<uint32_t>::max() - 10 ) )

--- a/src/cli/commands/io/verilog.cpp
+++ b/src/cli/commands/io/verilog.cpp
@@ -64,6 +64,6 @@ std::map<std::string, CommandHandler> register_verilog_commands()
 {
   return {
       { "read_verilog", cmd_read_verilog },
-      { "write_verilog", cmd_write_verilog },
+      { "write_verilog", cmd_write_verilog }
   };
 }

--- a/test/unit/databases/mapped_database.cpp
+++ b/test/unit/databases/mapped_database.cpp
@@ -6,13 +6,13 @@
 #include <vector>
 
 #include <lorina/genlib.hpp>
+#include <mockturtle/io/genlib_reader.hpp>
+#include <mockturtle/io/super_reader.hpp>
+#include <mockturtle/utils/tech_library.hpp>
 #include <rinox/analyzers/trackers/arrival_times_tracker.hpp>
 #include <rinox/databases/mapped_database.hpp>
 #include <rinox/evaluation/chains/bound_chain.hpp>
 #include <rinox/network/network.hpp>
-#include <mockturtle/io/genlib_reader.hpp>
-#include <mockturtle/io/super_reader.hpp>
-#include <mockturtle/utils/tech_library.hpp>
 
 using namespace mockturtle;
 
@@ -472,8 +472,14 @@ TEST_CASE( "Saving a mapped database", "[mapped_database]" )
   db.commit( out );
   std::string const expected =
       "module top( x0 , x1 , x2 , x3 , x4 , x5 , y0 , y1 );\n"
-      "  input x0 , x1 , x2 , x3 , x4 , x5 ;\n"
-      "  output y0 , y1 ;\n"
+      "  input x0 ;\n"
+      "  input x1 ;\n"
+      "  input x2 ;\n"
+      "  input x3 ;\n"
+      "  input x4 ;\n"
+      "  input x5 ;\n"
+      "  output y0 ;\n"
+      "  output y1 ;\n"
       "  wire n14 , n15 ;\n"
       "  XOR2   g0( .A (x4), .B (x5), .Y (y0) );\n"
       "  AND4   g1( .A (x3), .B (x4), .C (x5), .D (x2), .Y (n14) );\n"

--- a/test/unit/io/json.cpp
+++ b/test/unit/io/json.cpp
@@ -434,7 +434,7 @@ TEST_CASE( "Yosys syntax - case 1", "[json_parsing]" )
   std::string file = R"({
   "creator": "Rinox",
   "modules": {
-    "top": {
+    "mod1": {
       "attributes": {},
       "ports": {
         "a": { "direction": "input",  "bits": [ 2 ] },
@@ -505,7 +505,7 @@ TEST_CASE( "Yosys syntax - case 2", "[json_parsing]" )
   std::string file = R"({
   "creator": "Rinox",
   "modules": {
-    "top": {
+    "mod2": {
       "attributes": {},
       "ports": {
         "din":  { "direction": "input",  "bits": [ 20, 21, 22, 23 ], "offset": 0, "upto": 1, "signed": 1 },
@@ -600,7 +600,7 @@ TEST_CASE( "Read json without port direction", "[json_parsing]" )
   std::string file = R"({
   "creator": "Rinox",
   "modules": {
-    "top": {
+    "noport": {
       "attributes": {},
       "ports": {
         "a":   { "direction": "input",  "bits": [ 2 ] },

--- a/test/unit/io/verilog.cpp
+++ b/test/unit/io/verilog.cpp
@@ -156,7 +156,7 @@ TEST_CASE( "Read structural verilog to mapped network in the format used by abc"
     output \f[0] , \f[1] , \f[2], \f[3] ;
     wire n4 , n5 , n6 ;
     inv1 g0( .a (\a[0]), .O (n4) );
-    fa   g1( .b (\a[1]), .C (n5), .a (n4), .c (\b[0]), .S (n6) );
+    fa   g1( .b (\a[1]), .S (n5), .a (n4), .c (\b[0]), .C (n6) );
     inv1 g2( .a (n4), .O (\f[0]) );
     xor2 g3( .a (n6), .O (\f[1]), .b (\b[0]) );
     buf g4( .a (n5), .O (\f[2]) );

--- a/test/unit/io/verilog.cpp
+++ b/test/unit/io/verilog.cpp
@@ -75,8 +75,13 @@ TEST_CASE( "Read structural verilog to mapped network", "[verilog_reader]" )
   rinox::io::verilog::write_verilog( ntk, out );
 
   std::string expected = "module top( x0 , x1 , x2 , y0 , y1 , y2 , y3 );\n"
-                         "  input x0 , x1 , x2 ;\n"
-                         "  output y0 , y1 , y2 , y3 ;\n"
+                         "  input x0 ;\n"
+                         "  input x1 ;\n"
+                         "  input x2 ;\n"
+                         "  output y0 ;\n"
+                         "  output y1 ;\n"
+                         "  output y2 ;\n"
+                         "  output y3 ;\n"
                          "  wire n5 , n6_0 , n6_1 ;\n"
                          "  inv1  g0( .a (x0), .O (n5) );\n"
                          "  inv1  g1( .a (n5), .O (y0) );\n"
@@ -128,8 +133,13 @@ TEST_CASE( "Read structural verilog to mapped network  with the inputs permutate
   rinox::io::verilog::write_verilog( ntk, out );
 
   std::string expected = "module top( x0 , x1 , x2 , y0 , y1 , y2 , y3 );\n"
-                         "  input x0 , x1 , x2 ;\n"
-                         "  output y0 , y1 , y2 , y3 ;\n"
+                         "  input x0 ;\n"
+                         "  input x1 ;\n"
+                         "  input x2 ;\n"
+                         "  output y0 ;\n"
+                         "  output y1 ;\n"
+                         "  output y2 ;\n"
+                         "  output y3 ;\n"
                          "  wire n5 , n6_0 , n6_1 ;\n"
                          "  inv1  g0( .a (x0), .O (n5) );\n"
                          "  inv1  g1( .a (n5), .O (y0) );\n"
@@ -180,14 +190,15 @@ TEST_CASE( "Read structural verilog to mapped network in the format used by abc"
   rinox::io::verilog::write_verilog( ntk, out );
 
   std::string expected =
-      "module top( a[0] , a[1] , b[0] , f[0] , f[1] , f[2] , f[3] );\n"
-      "  input a[0] , a[1] , b[0] ;\n"
-      "  output f[0] , f[1] , f[2] , f[3] ;\n"
+      "module top( a , b , f );\n"
+      "  input [0:1] a ;\n"
+      "  input b ;\n"
+      "  output [0:3] f ;\n"
       "  wire n5 , n6_0 , n6_1 ;\n"
       "  inv1  g0( .a (a[0]), .O (n5) );\n"
       "  inv1  g1( .a (n5), .O (f[0]) );\n"
-      "  fa    g2( .a (n5), .b (a[1]), .c (b[0]), .C (n6_0), .S (n6_1) );\n"
-      "  xor2  g3( .a (n6_1), .b (b[0]), .O (f[1]) );\n"
+      "  fa    g2( .a (n5), .b (a[1]), .c (b), .S (n6_0), .C (n6_1) );\n"
+      "  xor2  g3( .a (n6_1), .b (b), .O (f[1]) );\n"
       "  buf   g4( .a (n6_0), .O (f[2]) );\n"
       "  buf   g5( .a (n6_1), .O (f[3]) );\n"
       "endmodule\n";
@@ -289,9 +300,9 @@ endmodule
   rinox::io::verilog::write_verilog( ntk, out );
 
   std::string expected =
-      "module top( xyz_inst.a[0] , xyz_inst.a[1] , xyz_inst.a[2] , xyz_inst.a[3] , xyz_inst.i0.a[0] , xyz_inst.i0.a[1] , xyz_inst.i0.a[2] , xyz_inst.i0.a[3] );\n"
-      "  input xyz_inst.a[0] , xyz_inst.a[1] , xyz_inst.a[2] , xyz_inst.a[3] ;\n"
-      "  output xyz_inst.i0.a[0] , xyz_inst.i0.a[1] , xyz_inst.i0.a[2] , xyz_inst.i0.a[3] ;\n"
+      "module top( xyz_inst.a , xyz_inst.i0.a );\n"
+      "  input [0:3] xyz_inst.a ;\n"
+      "  output [0:3] xyz_inst.i0.a ;\n"
       "  buf   g0( .a (xyz_inst.a[0]), .O (xyz_inst.i0.a[0]) );\n"
       "  assign xyz_inst.i0.a[1] = xyz_inst.a[1] ;\n"
       "  assign xyz_inst.i0.a[2] = xyz_inst.a[2] ;\n"
@@ -354,19 +365,26 @@ endmodule)";
   rinox::io::verilog::write_verilog( ntk, out );
 
   std::string expected =
-      "module top( xyz_inst.f00[0] , xyz_inst.f01[0] , xyz_inst.f02[0] , xyz_inst.f03[0] , xyz_inst.f04[0] , xyz_inst.f05[0] , xyz_inst.f06[0] , xyz_inst.f07[0] , xyz_inst.out0[0] , xyz_inst.out0[1] , xyz_inst.out0[2] , xyz_inst.out0[3] , xyz_inst.out0[4] , xyz_inst.out0[5] , xyz_inst.out0[6] , xyz_inst.out0[7] );\n"
-      "  input xyz_inst.f00[0] , xyz_inst.f01[0] , xyz_inst.f02[0] , xyz_inst.f03[0] , xyz_inst.f04[0] , xyz_inst.f05[0] , xyz_inst.f06[0] , xyz_inst.f07[0] ;\n"
-      "  output xyz_inst.out0[0] , xyz_inst.out0[1] , xyz_inst.out0[2] , xyz_inst.out0[3] , xyz_inst.out0[4] , xyz_inst.out0[5] , xyz_inst.out0[6] , xyz_inst.out0[7] ;\n"
+      "module top( xyz_inst.f00 , xyz_inst.f01 , xyz_inst.f02 , xyz_inst.f03 , xyz_inst.f04 , xyz_inst.f05 , xyz_inst.f06 , xyz_inst.f07 , xyz_inst.out0 );\n"
+      "  input xyz_inst.f00 ;\n"
+      "  input xyz_inst.f01 ;\n"
+      "  input xyz_inst.f02 ;\n"
+      "  input xyz_inst.f03 ;\n"
+      "  input xyz_inst.f04 ;\n"
+      "  input xyz_inst.f05 ;\n"
+      "  input xyz_inst.f06 ;\n"
+      "  input xyz_inst.f07 ;\n"
+      "  output [0:7] xyz_inst.out0 ;\n"
       "  wire n10 ;\n"
       "  and2  g0( .a (xyz_inst.out0[0]), .b (xyz_inst.out0[1]), .O (n10) );\n"
-      "  xor2  g1( .a (xyz_inst.f02[0]), .b (n10), .O (xyz_inst.out0[2]) );\n"
-      "  assign xyz_inst.out0[0] = xyz_inst.f00[0] ;\n"
-      "  assign xyz_inst.out0[1] = xyz_inst.f01[0] ;\n"
-      "  assign xyz_inst.out0[3] = xyz_inst.f03[0] ;\n"
-      "  assign xyz_inst.out0[4] = xyz_inst.f04[0] ;\n"
-      "  assign xyz_inst.out0[5] = xyz_inst.f05[0] ;\n"
-      "  assign xyz_inst.out0[6] = xyz_inst.f06[0] ;\n"
-      "  assign xyz_inst.out0[7] = xyz_inst.f07[0] ;\n"
+      "  xor2  g1( .a (xyz_inst.f02), .b (n10), .O (xyz_inst.out0[2]) );\n"
+      "  assign xyz_inst.out0[0] = xyz_inst.f00 ;\n"
+      "  assign xyz_inst.out0[1] = xyz_inst.f01 ;\n"
+      "  assign xyz_inst.out0[3] = xyz_inst.f03 ;\n"
+      "  assign xyz_inst.out0[4] = xyz_inst.f04 ;\n"
+      "  assign xyz_inst.out0[5] = xyz_inst.f05 ;\n"
+      "  assign xyz_inst.out0[6] = xyz_inst.f06 ;\n"
+      "  assign xyz_inst.out0[7] = xyz_inst.f07 ;\n"
       "endmodule\n";
 
   CHECK( out.str() == expected );
@@ -429,9 +447,10 @@ endmodule
   rinox::io::verilog::write_verilog( ntk, out );
 
   std::string expected =
-      "module top( a[0] , a[1] , b[0] , b[1] , xyz_inst.out1[0] , xyz_inst.out1[1] , xyz_inst.out1[2] , xyz_inst.out1[3] , xyz_inst.out1[4] , xyz_inst.out1[5] , xyz_inst.out1[6] , xyz_inst.out1[7] );\n"
-      "  input a[0] , a[1] , b[0] , b[1] ;\n"
-      "  output xyz_inst.out1[0] , xyz_inst.out1[1] , xyz_inst.out1[2] , xyz_inst.out1[3] , xyz_inst.out1[4] , xyz_inst.out1[5] , xyz_inst.out1[6] , xyz_inst.out1[7] ;\n"
+      "module top( a , b , xyz_inst.out1 );\n"
+      "  input [0:1] a ;\n"
+      "  input [0:1] b ;\n"
+      "  output [0:7] xyz_inst.out1 ;\n"
       "  wire n6 , n7 , n8 , n9 , n10 , n11 ;\n"
       "  inv2  g00( .a (0), .O (xyz_inst.out1[0]) );\n"
       "  inv2  g01( .a (0), .O (xyz_inst.out1[1]) );\n"
@@ -504,9 +523,9 @@ endmodule)";
   rinox::io::verilog::write_verilog( ntk, out );
 
   std::string expected =
-      "module top( ripple_inst.a[0] , ripple_inst.a[1] , ripple_inst.o[0] , ripple_inst.o[1] );\n"
-      "  input ripple_inst.a[0] , ripple_inst.a[1] ;\n"
-      "  output ripple_inst.o[0] , ripple_inst.o[1] ;\n"
+      "module top( ripple_inst.a , ripple_inst.o );\n"
+      "  input [0:1] ripple_inst.a ;\n"
+      "  output [0:1] ripple_inst.o ;\n"
       "  buf   g0( .a (ripple_inst.a[0]), .O (ripple_inst.o[0]) );\n"
       "  and2  g1( .a (ripple_inst.a[0]), .b (ripple_inst.a[1]), .O (ripple_inst.o[1]) );\n"
       "endmodule\n";


### PR DESCRIPTION
This PR addresses three improvements in RINOX IO:

1. Assigns the binding identifiers by name, not by order 
2. Writes to verilog in vector form, e.g., `input [0:7] A;`
3. Makes json parsing more general by allowing the top module to have any name